### PR TITLE
Optimizing the performance of searching

### DIFF
--- a/app/src/main/java/vegabobo/languageselector/ui/screen/main/MainScreen.kt
+++ b/app/src/main/java/vegabobo/languageselector/ui/screen/main/MainScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import vegabobo.languageselector.R
@@ -24,7 +23,6 @@ fun MainScreen(
     navigateToAbout: () -> Unit,
 ) {
     val uiState by mainScreenVm.uiState.collectAsState()
-    val pm = LocalContext.current.packageManager
 
     BaseScreen(
         screenTitle = stringResource(R.string.app_name),
@@ -52,21 +50,21 @@ fun MainScreen(
         ) {
             if (uiState.isLoading)
                 item { LinearProgressIndicator(modifier = Modifier.fillMaxWidth()) }
-            items(uiState.listOfApps.size) {
-                val thisPackage = uiState.listOfApps[it]
-                val appName = pm.getLabel(thisPackage)
-                val packageName = thisPackage.packageName
-                val appIconDrawable = pm.getAppIcon(thisPackage)
-                val containsInSearchQuery =
-                    packageName.lowercase().contains(mainScreenVm.searchQuery.value.lowercase()) ||
-                            appName.lowercase().contains(mainScreenVm.searchQuery.value.lowercase())
-                if (uiState.searchTextFieldValue == "" || containsInSearchQuery)
-                    AppListItem(
-                        packageName = packageName,
-                        appName = appName,
-                        drawable = appIconDrawable,
-                        onClickApp = { navigateToAppScreen(packageName) }
-                    )
+
+            val filteredApps = uiState.listOfApps.filter {
+                uiState.searchTextFieldValue == "" ||
+                        it.appPackageName.lowercase().contains(mainScreenVm.searchQuery.value.lowercase()) ||
+                        it.appName.lowercase().contains(mainScreenVm.searchQuery.value.lowercase())
+            }
+
+            items(filteredApps.size) {
+                val app = filteredApps[it]
+                AppListItem(
+                    packageName = app.appPackageName,
+                    appName = app.appName,
+                    drawable = app.appIcon,
+                    onClickApp = { navigateToAppScreen(app.appPackageName) }
+                )
             }
             item { Spacer(modifier = Modifier.padding(bottom = paddingValues.calculateBottomPadding())) }
         }

--- a/app/src/main/java/vegabobo/languageselector/ui/screen/main/MainScreenState.kt
+++ b/app/src/main/java/vegabobo/languageselector/ui/screen/main/MainScreenState.kt
@@ -14,7 +14,13 @@ data class MainScreenState(
     val isSearchVisible: Boolean = false,
      val isSystemAppDialogVisible: Boolean = false,
     val isAboutDialogVisible: Boolean = false,
-    val listOfApps: MutableList<ApplicationInfo> = mutableStateListOf()
+    val listOfApps: MutableList<AppInfo> = mutableStateListOf()
+)
+
+data class AppInfo (
+    val appIcon: Drawable,
+    val appName: String,
+    val appPackageName: String,
 )
 
 fun PackageManager.getLabel(applicationInfo: ApplicationInfo): String {

--- a/app/src/main/java/vegabobo/languageselector/ui/screen/main/MainScreenVm.kt
+++ b/app/src/main/java/vegabobo/languageselector/ui/screen/main/MainScreenVm.kt
@@ -43,8 +43,14 @@ class MainScreenVm @Inject constructor(
     fun fillListOfApps(getAlsoSystemApps: Boolean = false) {
         _uiState.value.listOfApps.clear()
         viewModelScope.launch(Dispatchers.IO) {
-            val packageList = getInstalledPackages(getAlsoSystemApps).map { it }
-            val sortedList = packageList.sortedBy { app.packageManager.getLabel(it).lowercase() }
+            val packageList = getInstalledPackages(getAlsoSystemApps).map {
+                AppInfo(
+                    appIcon = app.packageManager.getAppIcon(it),
+                    appName = app.packageManager.getLabel(it),
+                    appPackageName = it.packageName,
+                )
+            }
+            val sortedList = packageList.sortedBy { it.appName.lowercase() }
             _uiState.value.listOfApps.addAll(sortedList)
             _uiState.update { it.copy(isLoading = false) }
         }


### PR DESCRIPTION
The original version would cause the UI to be stuck for a long time (3~5s) on my phone  ( 900+ apps including system ones ). 
This PR contains the following improvements:
1. cache the app icon to avoid fetching every time recomposing;
2. filter the app list before passing it to LazyColumn.

It has already been tested on Mi14, HyperOS 1.0.36.0, which shows great searching performance improvement.